### PR TITLE
Use MetaPhysicL::raw_value in AD material power computation for stability

### DIFF
--- a/src/materials/directors/ADAnisotropicDirector.C
+++ b/src/materials/directors/ADAnisotropicDirector.C
@@ -67,7 +67,7 @@ ADAnisotropicDirector::computeQpProperties()
   {
     mooseInfo("Ensuring determinant of A = 1.");
     const ADReal detA = A.det();
-    A /= std::pow(detA, 1.0 / LIBMESH_DIM);
+    A /= std::pow(MetaPhysicL::raw_value(detA), 1.0 / LIBMESH_DIM);
   } 
   else if (_normalize_director == norm_type::factorial_norm)
   {

--- a/src/materials/mechanics/ADComputeFatigueEnergy.C
+++ b/src/materials/mechanics/ADComputeFatigueEnergy.C
@@ -115,8 +115,8 @@ ADComputeFatigueEnergy::computeQpProperties()
     else
     {
       current_psi = 2 * E * e_max * e_max 
-      * std::pow((1 + _R[_qp]) / 2, 2)
-      * std::pow((1 - _R[_qp]) / 2,_n[_qp]);
+      * std::pow((1 + MetaPhysicL::raw_value(_R[_qp])) / 2, 2)
+      * std::pow((1 - MetaPhysicL::raw_value(_R[_qp])) / 2,MetaPhysicL::raw_value(_n[_qp]));
     }
   }
   else if (_energy_calculation == "elastic_energy")

--- a/src/materials/phase_field_fracture/ADComputeExtraDrivingForce.C
+++ b/src/materials/phase_field_fracture/ADComputeExtraDrivingForce.C
@@ -69,7 +69,7 @@ ADComputeExtraDrivingForce::computeQpProperties()
   // Remember v=1-d
   ADReal wts = _sigma_ts[_qp]*_sigma_ts[_qp]/2/E;
   ADReal sigma_hs = (2*_sigma_ts[_qp]*_sigma_cs[_qp])/ 
-                    (3*std::max((_sigma_cs[_qp] - _sigma_ts[_qp]), 1e-9) );
+                    (3*std::max(MetaPhysicL::raw_value(_sigma_cs[_qp] - _sigma_ts[_qp]), 1e-9) );
   ADReal whs = sigma_hs*sigma_hs/2/k;
 
   ADReal beta1 = -1/sigma_hs*_delta_elp[_qp]*_gc[_qp]/8/_l[_qp]+2*whs/3/sigma_hs;
@@ -112,14 +112,14 @@ ADComputeExtraDrivingForce::computeQpProperties()
   if (_model == "finite_e")
   {
     mooseInfo("Using finite_e model");
-    _Ce[_qp] = beta2 * std::sqrt(J2) + beta1 * I1
-             + (1 / (_D[_qp] * std::sqrt(_D[_qp])))
+    _Ce[_qp] = beta2 * std::sqrt(MetaPhysicL::raw_value(J2)) + beta1 * I1
+             + (1 / (_D[_qp] * std::sqrt(MetaPhysicL::raw_value(_D[_qp]))))
              * (I1 < 0 ? 2 : 0) * (J2 * (1 + nu) / E + I1 * I1 * (1 - 2 * nu) / 6 / E);
   }
   else if (_model == "asymptotic")
   {
     mooseInfo("Using asymptotic model");
-    _Ce[_qp] = beta2 * std::sqrt(J2) + beta1 * I1;
+    _Ce[_qp] = beta2 * std::sqrt(MetaPhysicL::raw_value(J2)) + beta1 * I1;
   }
   else
   {

--- a/src/materials/phase_field_fracture/ADLinearElasticPFFractureStress.C
+++ b/src/materials/phase_field_fracture/ADLinearElasticPFFractureStress.C
@@ -67,8 +67,8 @@ ADLinearElasticPFFractureStress::computeStrainSpectral(ADReal & F_pos, ADReal & 
   std::vector<ADReal> epos(LIBMESH_DIM), eneg(LIBMESH_DIM);
   for (const auto i : make_range(Moose::dim))
   {
-    epos[i] = (std::abs(eigval[i]) + eigval[i]) / 2.0;
-    eneg[i] = -(std::abs(eigval[i]) - eigval[i]) / 2.0;
+    epos[i] = (std::abs(MetaPhysicL::raw_value(eigval[i])) + eigval[i]) / 2.0;
+    eneg[i] = -(std::abs(MetaPhysicL::raw_value(eigval[i])) - eigval[i]) / 2.0;
   }
 
   // Seprate positive and negative sums of all eigenvalues
@@ -76,8 +76,8 @@ ADLinearElasticPFFractureStress::computeStrainSpectral(ADReal & F_pos, ADReal & 
   for (const auto i : make_range(Moose::dim))
     etr += eigval[i];
 
-  const ADReal etrpos = (std::abs(etr) + etr) / 2.0;
-  const ADReal etrneg = -(std::abs(etr) - etr) / 2.0;
+  const ADReal etrpos = (std::abs(MetaPhysicL::raw_value(etr)) + etr) / 2.0;
+  const ADReal etrneg = -(std::abs(MetaPhysicL::raw_value(etr)) - etr) / 2.0;
 
   // Calculate the tensile (postive) and compressive (negative) parts of stress
   ADRankTwoTensor stress0pos, stress0neg;
@@ -181,7 +181,7 @@ ADLinearElasticPFFractureStress::computeStrainVolDev(ADReal & F_pos, ADReal & F_
   strain0dev = _mechanical_strain[_qp].deviatoric();
   strain0vol = _mechanical_strain[_qp] - strain0dev;
   strain0tr = _mechanical_strain[_qp].trace();
-  strain0tr_neg = std::min(strain0tr, 0.0);
+  strain0tr_neg = std::min(MetaPhysicL::raw_value(strain0tr), 0.0);
   strain0tr_pos = strain0tr - strain0tr_neg;
   stress0neg = k * strain0tr_neg * I2;
   stress0pos = _elasticity_tensor[_qp] * _mechanical_strain[_qp] - stress0neg;
@@ -230,7 +230,7 @@ ADLinearElasticPFFractureStress::computeStressDev(ADReal & F_pos, ADReal & F_neg
   ADRankFourTensor Jacobian_pos, Jacobian_neg;
   stress0dev = stress.deviatoric();
   ADReal stress0hydro = stress.trace()/LIBMESH_DIM;//should be /LIBMESH_DIM or /3??
-  ADReal stress0hydro_neg = std::min(stress0hydro, 0.0);
+  ADReal stress0hydro_neg = std::min(MetaPhysicL::raw_value(stress0hydro), 0.0);
   ADReal stress0hydro_pos = stress0hydro - stress0hydro_neg;
   // Create the positive and negative stress parts
   ADRankTwoTensor stress0pos = stress0hydro_pos * I2 + stress0dev;
@@ -295,7 +295,7 @@ ADLinearElasticPFFractureStress::computeStressRCE(ADReal & F_pos, ADReal & F_neg
     { 
       ADReal L1 = lambda/(lambda+2*mu)* _mechanical_strain[_qp].trace()
                   + 2*mu/(lambda+2*mu)* (_mechanical_strain[_qp]).doubleContraction(projections[i]);
-      Lam[i] = std::max(L1,0.0);
+      Lam[i] = std::max(MetaPhysicL::raw_value(L1),0.0);
       //if Lam[2]<0 
         //Lam[2] = 0.0;  
     }
@@ -361,7 +361,7 @@ ADLinearElasticPFFractureStress::computeStrainDruckerPrager(ADReal & F_pos, ADRe
   ADReal strain0tr = _mechanical_strain[_qp].trace();
   ADReal J2_strain  = 0.5 * strain0dev.doubleContraction(strain0dev);
   
-  ADReal J2_sqrt = std::sqrt(std::max(J2_strain, 0.0));
+  ADReal J2_sqrt = std::sqrt(std::max(MetaPhysicL::raw_value(J2_strain), 0.0));
   ADReal J2_sqrt_safe = (J2_strain < 1e-14) ? 1e-7 : J2_sqrt;
   // Stress for intact material
   ADRankTwoTensor stress0 = k * strain0tr * I2 + 2 * mu * strain0dev;

--- a/src/materials/phase_field_fracture/ADPFFRCEStress.C
+++ b/src/materials/phase_field_fracture/ADPFFRCEStress.C
@@ -107,7 +107,7 @@ ADPFFRCEStress::computeQpProperties()
     {
       ADReal L1 = lambda/(lambda+2*mu)* _strain[_qp].trace()
                 + 2*mu/(lambda+2*mu)* (_strain[_qp]).doubleContraction(projections[i]);
-      Lam[i] = std::max(L1,0.0);
+      Lam[i] = std::max(MetaPhysicL::raw_value(L1),0.0);
     }
     else 
     {
@@ -135,7 +135,7 @@ ADPFFRCEStress::computeQpProperties()
   if (_c[_qp] < 0.85)
     _hist[_qp] = psi_act;
   else
-    _hist[_qp] = std::max(psi_act, _hist_old[_qp]);
+    _hist[_qp] = std::max(MetaPhysicL::raw_value(psi_act), MetaPhysicL::raw_value(_hist_old[_qp]));
 
   ADReal hist_variable = _hist_old[_qp];
   if (_use_current_hist)

--- a/src/materials/phase_field_fracture/extra_driving_force_for_finite_strain/ADComputeExtraDrivingForcefromStress.C
+++ b/src/materials/phase_field_fracture/extra_driving_force_for_finite_strain/ADComputeExtraDrivingForcefromStress.C
@@ -67,7 +67,7 @@ ADComputeExtraDrivingForcefromStress::computeQpProperties()
   // Remember v=1-d
   ADReal wts = _sigma_ts[_qp]*_sigma_ts[_qp]/2/E;
   ADReal sigma_hs = (2*_sigma_ts[_qp]*_sigma_cs[_qp])/ 
-                    (3*std::max((_sigma_cs[_qp] - _sigma_ts[_qp]), 1e-9) );
+                    (3*std::max(MetaPhysicL::raw_value(_sigma_cs[_qp] - _sigma_ts[_qp]), 1e-9) );
   ADReal whs = sigma_hs*sigma_hs/2/k;
 
   ADReal beta1 = -1/sigma_hs*_delta_elp[_qp]*_gc[_qp]/8/_l[_qp]+2*whs/3/sigma_hs;
@@ -91,14 +91,14 @@ ADComputeExtraDrivingForcefromStress::computeQpProperties()
   if (_model == "finite_e")
   {
     mooseInfo("Using finite_e model");
-    _Ce[_qp] = beta2 * std::sqrt(J2) + beta1 * I1
-             + (1 / (_D[_qp] * std::sqrt(_D[_qp])))
+    _Ce[_qp] = beta2 * std::sqrt(MetaPhysicL::raw_value(J2)) + beta1 * I1
+             + (1 / (_D[_qp] * std::sqrt(MetaPhysicL::raw_value(_D[_qp]))))
              * (I1 < 0 ? 2 : 0) * (J2 * (1 + nu) / E + I1 * I1 * (1 - 2 * nu) / 6 / E);
   }
   else if (_model == "asymptotic")
   {
     mooseInfo("Using asymptotic model");
-    _Ce[_qp] = beta2 * std::sqrt(J2) + beta1 * I1;
+    _Ce[_qp] = beta2 * std::sqrt(MetaPhysicL::raw_value(J2)) + beta1 * I1;
   }
   else
   {

--- a/src/materials/porous_flow/PorousFlowPermeabilityTensorFromVarPFF.C
+++ b/src/materials/porous_flow/PorousFlowPermeabilityTensorFromVarPFF.C
@@ -67,7 +67,7 @@ PorousFlowPermeabilityTensorFromVarPFFTempl<is_ad>::computeQpProperties()
         _k_anisotropy * _perm[_qp] + _A[_qp] * (I2 - (*_crack_direction)[_qp]);
   else // exponential
     this->_permeability_qp[_qp] =
-        _k_anisotropy * _perm[_qp] * std::exp(_A[_qp]);
+        _k_anisotropy * _perm[_qp] * std::exp(MetaPhysicL::raw_value(_A[_qp]));
 
   _perm_out[_qp]              = this->_permeability_qp[_qp];
 


### PR DESCRIPTION
This PR updates a computation involving ADReal to explicitly use MetaPhysicL::raw_value before passing it into std::pow.